### PR TITLE
Use CloudEnvironment::getenv method when looking for Acquia Hosting variables

### DIFF
--- a/src/Acquia/Cloud/Environment/CloudEnvironment.php
+++ b/src/Acquia/Cloud/Environment/CloudEnvironment.php
@@ -26,11 +26,33 @@ class CloudEnvironment extends Environment implements CloudEnvironmentInterface
     private $creds;
 
     /**
+     * Acquia Cloud variables may be set in settings.inc after PHP init,
+     * so make sure that we are loading them.
+     *
+     * @param string $key
+     * @return string The value of the environment variable or false if not found
+     * @see https://github.com/acquia/acquia-sdk-php/pull/58#issuecomment-45167451
+     */
+    protected function getenv($key)
+    {
+        $value = getenv($key);
+        if ($value === false) {
+            if (isset($_ENV[$key])) {
+                $value = $_ENV[$key];
+            }
+            if (isset($_SERVER[$key])) {
+                $value = $_SERVER[$key];
+            }
+        }
+        return $value;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function init()
     {
-        $environment = $_ENV['AH_SITE_ENVIRONMENT'];
+        $environment = $this->getenv('AH_SITE_ENVIRONMENT');
         return $environment ?: self::LOCAL;
     }
 
@@ -47,7 +69,7 @@ class CloudEnvironment extends Environment implements CloudEnvironmentInterface
      */
     public function isProduction()
     {
-        return (bool) $_ENV['AH_PRODUCTION'];
+        return (bool) $this->getenv('AH_PRODUCTION');
     }
 
     /**
@@ -69,7 +91,7 @@ class CloudEnvironment extends Environment implements CloudEnvironmentInterface
     public function getSiteGroup()
     {
         if (!isset($this->sitegroup)) {
-            $this->sitegroup = $_ENV['AH_SITE_GROUP'];
+            $this->sitegroup = $this->getenv('AH_SITE_GROUP');
             if (!$this->sitegroup) {
                 throw new \UnexpectedValueException('Expecting environment variable AH_SITE_GROUP to be set');
             }

--- a/test/Acquia/Test/Cloud/Environment/CloudEnvironmentTest.php
+++ b/test/Acquia/Test/Cloud/Environment/CloudEnvironmentTest.php
@@ -12,21 +12,25 @@ class CloudEnvironmentTest extends \PHPUnit_Framework_TestCase
 
     protected $originalEnv;
     protected $originalProduction;
+    protected $originalSiteEnv;
     protected $originalSiteGroup;
+    protected $originalServer;
 
     public function setUp()
     {
-        $this->originalEnv = $_ENV['AH_SITE_ENVIRONMENT'];
-        $this->originalProduction = $_ENV['AH_PRODUCTION'];
-        $this->originalSiteGroup = $_ENV['AH_SITE_GROUP'];
+        $this->originalEnv = $_ENV;
+        $this->originalServer = $_SERVER;
+        $this->originalSiteEnv = getenv('AH_SITE_ENVIRONMENT');
+        $this->originalProduction = getenv('AH_PRODUCTION');
+        $this->originalSiteGroup = getenv('AH_SITE_GROUP');
         putenv('AH_SITE_GROUP=' . self::SITEGROUP);
         parent::setUp();
     }
 
     public function tearDown()
     {
-        if ($this->originalEnv) {
-            putenv('AH_SITE_ENVIRONMENT=' . $this->originalEnv);
+        if ($this->originalSiteEnv) {
+            putenv('AH_SITE_ENVIRONMENT=' . $this->originalSiteEnv);
             putenv('AH_PRODUCTION=' . $this->originalProduction);
             putenv('AH_SITE_GROUP=' . $this->originalSiteGroup);
         } else {
@@ -34,6 +38,8 @@ class CloudEnvironmentTest extends \PHPUnit_Framework_TestCase
             putenv('AH_PRODUCTION');
             putenv('AH_SITE_GROUP');
         }
+        $_ENV = $this->originalEnv;
+        $_SERVER = $this->originalServer;
         parent::tearDown();
     }
 
@@ -119,7 +125,9 @@ class CloudEnvironmentTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoSiteGroup()
     {
-        putenv('AH_SITE_GROUP');
+        putenv('AH_SITE_GROUP=');
+        unset($_SERVER['AH_SITE_GROUP']);
+        unset($_ENV['AH_SITE_GROUP']);
         $env = new CloudEnvironment();
         $env->getSiteGroup();
     }


### PR DESCRIPTION
This PR builds off of the work @jacobbednarz provided in #58. Because Acquia Hosting inserts keys into $_ENV directly (when php_sapi() == CLI), getenv does not reliably get Acquia Hosting special vars. I added a wrapper to check getenv, $_ENV, and $_SERVER for a key and return its value.
