### PR TITLE
acquia-search-governor-php cannot read stored auth data

### DIFF
--- a/src/Acquia/Rest/ServiceManager.php
+++ b/src/Acquia/Rest/ServiceManager.php
@@ -218,7 +218,11 @@ class ServiceManager extends \ArrayObject
      * @return \Guzzle\Service\Client
      */
     public function getClient($group, $name)
-    {
+    {   
+        // when used with https://github.com/acquia/acquia-search-governor-php
+        // this isset fails, unless the private storage property of the 
+        // ArrayObject $this has previously been accessed. I don't know why this works but it does.
+        $foo = $this[$group];
         return isset($this[$group][$name]) ? $this[$group][$name] : null;
     }
 


### PR DESCRIPTION
I know the code doesn't seem to make a lot of sense and I cannot say what the bug is but with PHP 7.1 (after the Mojave update) this very simple function

`    public function getClient($group, $name)
    {
        return isset($this[$group][$name]) ? $this[$group][$name] : null;
    }`

... will return null even though the ArrayObject $this *should* have populated properties in it's storage. If you access those properties (e.g. with a print_r, or var_dump, or even assign them to a variable) before the isset is called, it all just works as expected.