### PR TITLE
Link to replacement library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## NOTE: This repository is no longer actively maintained and has not been updated to support PHP 7.1
 
+Instead, please upgrade to [typhonius/acquia-php-sdk-v2](https://github.com/typhonius/acquia-php-sdk-v2).
+
 # Acquia SDK for PHP
 
 [![Build Status](https://travis-ci.org/acquia/acquia-sdk-php.svg?branch=master)](https://travis-ci.org/acquia/acquia-sdk-php)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "acquia/acquia-sdk-php",
     "type": "library",
+    "abandoned": "typhonius/acquia-php-sdk-v2",
     "description": "The Acquia SDK for PHP allows developers to build applications on top of Acquia services.",
     "keywords": ["acquia"],
     "homepage": "https://github.com/acquia/acquia-sdk-php",


### PR DESCRIPTION
Let's point users to a maintained library. After, I think it's safe to say this repo can be archived?

As well, I don't see the package having auto updates on packagist, so given the age the release may need to be done manually.